### PR TITLE
fix regex string matching of !roles command

### DIFF
--- a/src/modules/roles.js
+++ b/src/modules/roles.js
@@ -170,10 +170,23 @@ module.exports = ({ bot, knex, config, commands }) => {
     "<role:string$>",
     async (msg, args, thread) => {
       const channel = await getOrFetchChannel(bot, msg.channel.id);
-      const role = resolveRoleInput(args.role);
-      if (!role || !msg.member.roles.includes(role.id)) {
+      const roleArr = resolveRoleInput(args.role);
+      const out = resolveRoleFromRoleArray(roleArr, args.role);
+
+      if (out.msg) {
+        channel.createMessage(out.msg);
+        return;
+      } else if (!out.role) {
         channel.createMessage(
-          "No matching role found. Make sure you have the role before trying to set it as your default display role."
+          `No role in the server matches the input \`${args.role}\`.`
+        );
+        return;
+      }
+
+      const role = out.role;
+      if (!msg.member.roles.includes(role.id)) {
+        channel.createMessage(
+          `You do not have the role \`${role.name}\` assigned to you. You can only set roles you own as the display role of the thread.`
         );
         return;
       }

--- a/src/modules/roles.js
+++ b/src/modules/roles.js
@@ -9,10 +9,10 @@ const {
   getModeratorThreadDisplayRoleName,
   getModeratorDefaultDisplayRoleName,
 } = require("../data/displayRoles");
-const {getOrFetchChannel} = require("../utils");
+const { getOrFetchChannel } = require("../utils");
 
 module.exports = ({ bot, knex, config, commands }) => {
-  if (! config.allowChangingDisplayRole) {
+  if (!config.allowChangingDisplayRole) {
     return;
   }
 
@@ -21,82 +21,173 @@ module.exports = ({ bot, knex, config, commands }) => {
       return utils.getInboxGuild().roles.get(input);
     }
 
-    return utils.getInboxGuild().roles.find(r => r.name.toLowerCase() === input.toLowerCase());
+    const regex = new RegExp(`^(${input.toLowerCase()}.*)$`);
+    return utils
+      .getInboxGuild()
+      .roles.filter((r) => regex.test(r.name.toLowerCase()));
+  }
+
+  function resolveRoleFromRoleArray(roleArr, input) {
+    let role = null;
+    let msg = null;
+    if (roleArr.length == 1) {
+      role = roleArr[0];
+    } else if (roleArr.length > 1) {
+      msg = `Multiple roles match the input \`${input}\`:`;
+      for (const role of roleArr) {
+        msg += `\n- ${role.name}`;
+      }
+    }
+
+    return { role, msg };
   }
 
   // Get display role for a thread
-  commands.addInboxThreadCommand("role", [], async (msg, args, thread) => {
-    const displayRole = await getModeratorThreadDisplayRoleName(msg.member, thread.id);
-    if (displayRole) {
-      thread.postSystemMessage(`Your display role in this thread is currently **${displayRole}**`);
-    } else {
-      thread.postSystemMessage("Your replies in this thread do not currently display a role");
-    }
-  }, { allowSuspended: true });
+  commands.addInboxThreadCommand(
+    "role",
+    [],
+    async (msg, args, thread) => {
+      const displayRole = await getModeratorThreadDisplayRoleName(
+        msg.member,
+        thread.id
+      );
+      if (displayRole) {
+        thread.postSystemMessage(
+          `Your display role in this thread is currently **${displayRole}**`
+        );
+      } else {
+        thread.postSystemMessage(
+          "Your replies in this thread do not currently display a role"
+        );
+      }
+    },
+    { allowSuspended: true }
+  );
 
   // Reset display role for a thread
-  commands.addInboxThreadCommand("role reset", [], async (msg, args, thread) => {
-    await resetModeratorThreadRoleOverride(msg.member.id, thread.id);
+  commands.addInboxThreadCommand(
+    "role reset",
+    [],
+    async (msg, args, thread) => {
+      await resetModeratorThreadRoleOverride(msg.member.id, thread.id);
 
-    const displayRole = await getModeratorThreadDisplayRoleName(msg.member, thread.id);
-    if (displayRole) {
-      thread.postSystemMessage(`Your display role for this thread has been reset. Your replies will now display the default role **${displayRole}**.`);
-    } else {
-      thread.postSystemMessage("Your display role for this thread has been reset. Your replies will no longer display a role.");
+      const displayRole = await getModeratorThreadDisplayRoleName(
+        msg.member,
+        thread.id
+      );
+      if (displayRole) {
+        thread.postSystemMessage(
+          `Your display role for this thread has been reset. Your replies will now display the default role **${displayRole}**.`
+        );
+      } else {
+        thread.postSystemMessage(
+          "Your display role for this thread has been reset. Your replies will no longer display a role."
+        );
+      }
+    },
+    {
+      aliases: ["role_reset", "reset_role"],
+      allowSuspended: true,
     }
-  }, {
-    aliases: ["role_reset", "reset_role"],
-    allowSuspended: true,
-  });
+  );
 
   // Set display role for a thread
-  commands.addInboxThreadCommand("role", "<role:string$>", async (msg, args, thread) => {
-    const role = resolveRoleInput(args.role);
-    if (! role || ! msg.member.roles.includes(role.id)) {
-      thread.postSystemMessage("No matching role found. Make sure you have the role before trying to set it as your display role in this thread.");
-      return;
-    }
+  commands.addInboxThreadCommand(
+    "role",
+    "<role:string$>",
+    async (msg, args, thread) => {
+      const roleArr = resolveRoleInput(args.role);
+      const out = resolveRoleFromRoleArray(roleArr, args.role);
 
-    await setModeratorThreadRoleOverride(msg.member.id, thread.id, role.id);
-    thread.postSystemMessage(`Your display role for this thread has been set to **${role.name}**. You can reset it with \`${config.prefix}role reset\`.`);
-  }, { allowSuspended: true });
+      if (out.msg) {
+        thread.postSystemMessage(out.msg);
+        return;
+      } else if (!out.role) {
+        thread.postSystemMessage(
+          `No role in the server matches the input \`${args.role}\`.`
+        );
+        return;
+      } else if (!out.role) {
+        // Uh-oh.
+        thread.postSystemMessage(
+          `Something went wrong. Please contact a developer for help..`
+        );
+        return;
+      }
+
+      const role = out.role;
+      if (!msg.member.roles.includes(role.id)) {
+        thread.postSystemMessage(
+          `You do not have the role \`${role.name}\` assigned to you. You can only set roles you own as the display role of the thread.`
+        );
+        return;
+      }
+
+      await setModeratorThreadRoleOverride(msg.member.id, thread.id, role.id);
+      thread.postSystemMessage(
+        `Your display role for this thread has been set to **${role.name}**. You can reset it with \`${config.prefix}role reset\`.`
+      );
+    },
+    { allowSuspended: true }
+  );
 
   // Get default display role
   commands.addInboxServerCommand("role", [], async (msg, args, thread) => {
     const channel = await getOrFetchChannel(bot, msg.channel.id);
     const displayRole = await getModeratorDefaultDisplayRoleName(msg.member);
     if (displayRole) {
-      channel.createMessage(`Your default display role is currently **${displayRole}**`);
+      channel.createMessage(
+        `Your default display role is currently **${displayRole}**`
+      );
     } else {
-      channel.createMessage("Your replies do not currently display a role by default");
+      channel.createMessage(
+        "Your replies do not currently display a role by default"
+      );
     }
   });
 
   // Reset default display role
-  commands.addInboxServerCommand("role reset", [], async (msg, args, thread) => {
-    await resetModeratorDefaultRoleOverride(msg.member.id);
+  commands.addInboxServerCommand(
+    "role reset",
+    [],
+    async (msg, args, thread) => {
+      await resetModeratorDefaultRoleOverride(msg.member.id);
 
-    const channel = await getOrFetchChannel(bot, msg.channel.id);
-    const displayRole = await getModeratorDefaultDisplayRoleName(msg.member);
-    if (displayRole) {
-      channel.createMessage(`Your default display role has been reset. Your replies will now display the role **${displayRole}** by default.`);
-    } else {
-      channel.createMessage("Your default display role has been reset. Your replies will no longer display a role by default.");
+      const channel = await getOrFetchChannel(bot, msg.channel.id);
+      const displayRole = await getModeratorDefaultDisplayRoleName(msg.member);
+      if (displayRole) {
+        channel.createMessage(
+          `Your default display role has been reset. Your replies will now display the role **${displayRole}** by default.`
+        );
+      } else {
+        channel.createMessage(
+          "Your default display role has been reset. Your replies will no longer display a role by default."
+        );
+      }
+    },
+    {
+      aliases: ["role_reset", "reset_role"],
     }
-  }, {
-    aliases: ["role_reset", "reset_role"],
-  });
+  );
 
   // Set default display role
-  commands.addInboxServerCommand("role", "<role:string$>", async (msg, args, thread) => {
-    const channel = await getOrFetchChannel(bot, msg.channel.id);
-    const role = resolveRoleInput(args.role);
-    if (! role || ! msg.member.roles.includes(role.id)) {
-      channel.createMessage("No matching role found. Make sure you have the role before trying to set it as your default display role.");
-      return;
-    }
+  commands.addInboxServerCommand(
+    "role",
+    "<role:string$>",
+    async (msg, args, thread) => {
+      const channel = await getOrFetchChannel(bot, msg.channel.id);
+      const role = resolveRoleInput(args.role);
+      if (!role || !msg.member.roles.includes(role.id)) {
+        channel.createMessage(
+          "No matching role found. Make sure you have the role before trying to set it as your default display role."
+        );
+        return;
+      }
 
-    await setModeratorDefaultRoleOverride(msg.member.id, role.id);
-    channel.createMessage(`Your default display role has been set to **${role.name}**. You can reset it with \`${config.prefix}role reset\`.`);
-  });
+      await setModeratorDefaultRoleOverride(msg.member.id, role.id);
+      channel.createMessage(
+        `Your default display role has been set to **${role.name}**. You can reset it with \`${config.prefix}role reset\`.`
+      );
+    }
+  );
 };

--- a/src/modules/roles.js
+++ b/src/modules/roles.js
@@ -107,12 +107,6 @@ module.exports = ({ bot, knex, config, commands }) => {
           `No role in the server matches the input \`${args.role}\`.`
         );
         return;
-      } else if (!out.role) {
-        // Uh-oh.
-        thread.postSystemMessage(
-          `Something went wrong. Please contact a developer for help..`
-        );
-        return;
       }
 
       const role = out.role;


### PR DESCRIPTION
## Breaking changes
- `resolveRoleInput` now returns an array of **all** matching roles instead of just the first role.
  - The new function `resolveRoleFromRoleArray` has been added to resolve the role into either a message with a list of all
matching roles, or the matching role if only one was found. Further checks are needed to output the proper system messages.

## Features 
- !roles now uses the regex `/^(${str}.*)$/` to match strings from the beginning.
  - This behavior applies for both the `inboxServer` and `inboxThread` variations of the command.
- When the regex match returns multiple strings, the results will be outputted as a system/thread message.
