### PR TITLE
fixed attachments not rendering

### DIFF
--- a/plugins/EmbedMessages-main/embedMessages.js
+++ b/plugins/EmbedMessages-main/embedMessages.js
@@ -181,11 +181,34 @@ module.exports = async function ({ config, bot, formats }) {
     return pfp;
   }
 
+  // Parses all the attachments of the threadMessage and attaches them to the embed.
+  function parseAndAttachToEmbed(threadMessage, embed) {
+      if (threadMessage.attachments.length === 1) {
+      const url = threadMessage.attachments[0];
+      const noQueryUrl = new URL(url).origin + new URL(url).pathname;
+      if (
+        noQueryUrl.endsWith(".png")  ||
+        noQueryUrl.endsWith(".jpg") ||
+        noQueryUrl.endsWith(".gif")
+      ) {
+        embed.image = {
+          url: noQueryUrl,
+        };
+      } else {
+        embed.description += `\n${noQueryUrl}`;
+      }
+    } else {
+      for (const link of threadMessage.attachments) {
+        embed.description += `\n${link}`;
+      }
+    }
+  }
+
   const replyToUserFormatter = function (threadMessage) {
     const userId = threadMessage.user_id;
     const roleName = threadMessage.role_name || config.fallbackRoleName || "";
     const embed = { description: threadMessage.original_body, color: settings.get(SETTING_NAMES.STAFF_REPLY_DM_COLOR) };
-
+    
     if (!threadMessage.is_anonymous) {
       embed.author = {
         name: `${threadMessage.user_name} ${roleName != "" ? `(${roleName})` : ""}`.trim(),
@@ -198,23 +221,7 @@ module.exports = async function ({ config, bot, formats }) {
       };
     }
 
-    if (threadMessage.attachments.length === 1) {
-      if (
-        threadMessage.attachments[0].endsWith(".png") ||
-        threadMessage.attachments[0].endsWith(".jpg") ||
-        threadMessage.attachments[0].endsWith(".gif")
-      ) {
-        embed.image = {
-          url: threadMessage.attachments[0],
-        };
-      } else {
-        embed.description += `\n${threadMessage.attachments[0]}`;
-      }
-    } else {
-      for (const link of threadMessage.attachments) {
-        embed.description += `\n${link}`;
-      }
-    }
+    parseAndAttachToEmbed(threadMessage, embed);
 
     if (config.threadTimestamps && settings.get(SETTING_NAMES.STAFF_REPLY_DM_TIMESTAMP_ENABLE)) {
       embed.timestamp = moment().utc().toISOString();
@@ -244,23 +251,7 @@ module.exports = async function ({ config, bot, formats }) {
       };
     }
 
-    if (threadMessage.attachments.length === 1) {
-      if (
-        threadMessage.attachments[0].endsWith(".png") ||
-        threadMessage.attachments[0].endsWith(".jpg") ||
-        threadMessage.attachments[0].endsWith(".gif")
-      ) {
-        embed.image = {
-          url: threadMessage.attachments[0],
-        };
-      } else {
-        embed.description += `\n${threadMessage.attachments[0]}`;
-      }
-    } else {
-      for (const link of threadMessage.attachments) {
-        embed.description += `\n${link}`;
-      }
-    }
+    parseAndAttachToEmbed(threadMessage, embed);
 
     if (config.threadTimestamps) {
       embed.timestamp = moment().utc().toISOString();
@@ -271,24 +262,26 @@ module.exports = async function ({ config, bot, formats }) {
 
   const userReplyFormatter = function (threadMessage) {
     const userId = threadMessage.user_id;
-    const embed = { description: threadMessage.original_body, color: settings.get(SETTING_NAMES.USER_REPLY_THREAD_COLOR) };
-
+    const embed = { description: threadMessage.original_body, color: settings.get(SETTING_NAMES.USER_REPLY_THREAD_COLOR) }; 
     embed.author = {
       name: `${threadMessage.user_name}`,
       icon_url: getPfp(userId),
     };
 
+    
     if (threadMessage.attachments.length === 1) {
+      const url = threadMessage.attachments[0];
+      const noQueryUrl = new URL(url).origin + new URL(url).pathname;
       if (
-        threadMessage.attachments[0].endsWith(".png") ||
-        threadMessage.attachments[0].endsWith(".jpg") ||
-        threadMessage.attachments[0].endsWith(".gif")
+        noQueryUrl.endsWith(".png")  ||
+        noQueryUrl.endsWith(".jpg") ||
+        noQueryUrl.endsWith(".gif")
       ) {
         embed.image = {
-          url: threadMessage.attachments[0],
+          url: noQueryUrl,
         };
       } else {
-        embed.description += `\n${threadMessage.attachments[0]}`;
+        embed.description += `\n${noQueryUrl}`;
       }
     } else {
       for (const link of threadMessage.attachments) {
@@ -311,23 +304,7 @@ module.exports = async function ({ config, bot, formats }) {
       icon_url: bot.user.avatarURL,
     };
 
-    if (threadMessage.attachments.length === 1) {
-      if (
-        threadMessage.attachments[0].endsWith(".png") ||
-        threadMessage.attachments[0].endsWith(".jpg") ||
-        threadMessage.attachments[0].endsWith(".gif")
-      ) {
-        embed.image = {
-          url: threadMessage.attachments[0],
-        };
-      } else {
-        embed.description += `\n${threadMessage.attachments[0]}`;
-      }
-    } else {
-      for (const link of threadMessage.attachments) {
-        embed.description += `\n${link}`;
-      }
-    }
+    parseAndAttachToEmbed(threadMessage, embed);
 
     if (config.threadTimestamps && settings.get(SETTING_NAMES.STAFF_REPLY_DM_TIMESTAMP_ENABLE)) {
       embed.timestamp = moment().utc().toISOString();
@@ -344,23 +321,7 @@ module.exports = async function ({ config, bot, formats }) {
       icon_url: bot.user.avatarURL,
     };
 
-    if (threadMessage.attachments.length === 1) {
-      if (
-        threadMessage.attachments[0].endsWith(".png") ||
-        threadMessage.attachments[0].endsWith(".jpg") ||
-        threadMessage.attachments[0].endsWith(".gif")
-      ) {
-        embed.image = {
-          url: threadMessage.attachments[0],
-        };
-      } else {
-        embed.description += `\n${threadMessage.attachments[0]}`;
-      }
-    } else {
-      for (const link of threadMessage.attachments) {
-        embed.description += `\n${link}`;
-      }
-    }
+    parseAndAttachToEmbed(threadMessage, embed);
     
     if (config.threadTimestamps) {
       embed.timestamp = moment().utc().toISOString();
@@ -377,23 +338,7 @@ module.exports = async function ({ config, bot, formats }) {
       icon_url: bot.user.avatarURL,
     };
 
-    if (threadMessage.attachments.length === 1) {
-      if (
-        threadMessage.attachments[0].endsWith(".png") ||
-        threadMessage.attachments[0].endsWith(".jpg") ||
-        threadMessage.attachments[0].endsWith(".gif")
-      ) {
-        embed.image = {
-          url: threadMessage.attachments[0],
-        };
-      } else {
-        embed.description += `\n${threadMessage.attachments[0]}`;
-      }
-    } else {
-      for (const link of threadMessage.attachments) {
-        embed.description += `\n${link}`;
-      }
-    }
+    parseAndAttachToEmbed(threadMessage, embed);
 
     // We can't directly join the matched array since that results in "@Dark,108552944961454080"
     const foundMentions = threadMessage.original_body.matchAll(mentionRegex);

--- a/src/data/Thread.js
+++ b/src/data/Thread.js
@@ -331,6 +331,14 @@ class Thread {
       for (const attachment of replyAttachments) {
         await Promise.all([
           attachments.attachmentToDiscordFileObject(attachment).then((file) => {
+            const noQueryUrl =
+              new URL(attachment.url).origin + new URL(attachment.url).pathname;
+            if (
+              noQueryUrl.endsWith(".png") ||
+              noQueryUrl.endsWith(".jpg") ||
+              noQueryUrl.endsWith(".gif")
+            )
+              return;
             files.push(file);
           }),
           attachments.saveAttachment(attachment).then((result) => {
@@ -1099,7 +1107,9 @@ class Thread {
       await this._addThreadMessageToDB(editThreadMessage.getSQLProps());
     }
 
-    await this._updateThreadMessage(threadMessage.id, { original_body: newText });
+    await this._updateThreadMessage(threadMessage.id, {
+      original_body: newText,
+    });
     return true;
   }
 


### PR DESCRIPTION
## Changes
- Added `parseAndAttachToEmbed()` to `plugins/EmbedMessages-main/embedMessages.js` to properly parse URLs. Before this, query parameters were included in the parsed strings which caused file extension scans to not work using `endsWith()`.
- Filtered for `.jpg` `.png` and `.gif` attachments in `Thread.js/replyToUser`. This was previously causing a double-post if one attached files of those types, but probably wasn't noticed because the images weren't rendering in the embed prior to this patch.